### PR TITLE
Eliminate whitespace in fact keys

### DIFF
--- a/.github/workflows/pdk.yml
+++ b/.github/workflows/pdk.yml
@@ -13,8 +13,10 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
-          curl -JLO 'https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=ubuntu&rel=20.04&arch=amd64&ver=2.5.0.0'
-          sudo dpkg -i pdk_2.5.0.0-1focal_amd64.deb
+          wget https://apt.puppet.com/puppet-tools-release-jammy.deb
+          sudo dpkg -i puppet-tools-release-jammy.deb
+          sudo apt-get update
+          sudo apt-get install pdk
 
       - name: Install PDK Ruby Dependencies
         run: pdk bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development do
   gem "rubocop", '= 1.48.1',                     require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
+  gem "puppet-strings", '~> 4.0',                require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do

--- a/README.md
+++ b/README.md
@@ -38,27 +38,27 @@ Just install this module and `puppet facts | jq '.values.ethtool'` should show s
 {
   "eno1": {
     "ring": {
-      "Pre-set maximums": {
+      "Pre-set_maximums": {
         "RX": "4096",
-        "RX Mini": "n/a",
-        "RX Jumbo": "n/a",
+        "RX_Mini": "n/a",
+        "RX_Jumbo": "n/a",
         "TX": "4096"
       },
-      "Current hardware settings": {
+      "Current_hardware_settings": {
         "RX": "4096",
-        "RX Mini": "n/a",
-        "RX Jumbo": "n/a",
+        "RX_Mini": "n/a",
+        "RX_Jumbo": "n/a",
         "TX": "4096"
       }
     },
     "channels": {
-      "Pre-set maximums": {
+      "Pre-set_maximums": {
         "RX": "n/a",
         "TX": "n/a",
         "Other": "1",
         "Combined": "63"
       },
-      "Current hardware settings": {
+      "Current_hardware_settings": {
         "RX": "n/a",
         "TX": "n/a",
         "Other": "1",

--- a/lib/facter/ethtool.rb
+++ b/lib/facter/ethtool.rb
@@ -22,13 +22,13 @@ Facter.add(:ethtool) do
       line = line.strip
       if line.end_with?(':')
         subsection_title = line.chop
-        subsection_title = subsection_title.gsub(/ /, '_')
+        subsection_title = subsection_title.tr(' ', '_')
         result[subsection_title] = {}
         current_subsection = result[subsection_title]
       else
         parts = line.split(':')
         if parts.length == 2
-          current_subsection[parts[0].strip.gsub(/ /, '_')] = parts[1].strip
+          current_subsection[parts[0].strip.tr(' ', '_')] = parts[1].strip
         end
       end
     end

--- a/lib/facter/ethtool.rb
+++ b/lib/facter/ethtool.rb
@@ -22,12 +22,13 @@ Facter.add(:ethtool) do
       line = line.strip
       if line.end_with?(':')
         subsection_title = line.chop
+        subsection_title = subsection_title.gsub(/ /, '_')
         result[subsection_title] = {}
         current_subsection = result[subsection_title]
       else
         parts = line.split(':')
         if parts.length == 2
-          current_subsection[parts[0].strip] = parts[1].strip
+          current_subsection[parts[0].strip.gsub(/ /, '_')] = parts[1].strip
         end
       end
     end
@@ -37,7 +38,6 @@ Facter.add(:ethtool) do
 
   setcode do
     result = {}
-
     Facter.value(:networking)['interfaces'].each do |interface, _|
       result[interface] = {}
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "phihos-ethtool_facts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Philipp Hossner",
   "summary": "Custom fact containing ethtool output for every interface.",
   "license": "MIT",
@@ -66,7 +66,7 @@
       "version_requirement": ">= 7.24 < 9.0.0"
     }
   ],
-  "pdk-version": "3.0.0",
-  "template-url": "pdk-default#3.0.0",
-  "template-ref": "tags/3.0.0-0-g056e50d"
+  "pdk-version": "3.0.1",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#3.0.0",
+  "template-ref": "tags/3.0.0-0-g5bfc1c0"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,8 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-ipaddress: "172.16.254.254"
-ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+networking:
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
 is_pe: false
-macaddress: "AA:AA:AA:AA:AA:AA"

--- a/spec/unit/facter/ethtool_spec.rb
+++ b/spec/unit/facter/ethtool_spec.rb
@@ -150,6 +150,8 @@ describe :ethtool, type: :fact do
     # perform any action that should be run before every test
     Facter.clear
     require 'facter/ethtool'
+    allow(Facter::Core::Execution).to receive(:which).and_call_original
+    allow(Facter::Core::Execution).to receive(:which).with('ethtool').and_return('/usr/bin/ethtool')
     allow(Facter.fact(:networking)).to receive(:value).and_return(
       {
         'interfaces' => {
@@ -169,34 +171,34 @@ describe :ethtool, type: :fact do
                             {
                               'eno1' => {
                                 'ring' => {
-                                  'Current hardware settings' => {
-                                    'CQE Size' => 'n/a',
+                                  'Current_hardware_settings' => {
+                                    'CQE_Size' => 'n/a',
                                     'RX' => '256',
-                                    'RX Buf Len' => 'n/a',
-                                    'RX Jumbo' => 'n/a',
-                                    'RX Mini' => 'n/a',
-                                    'RX Push' => 'n/a',
-                                    'TCP data split' => 'n/a',
+                                    'RX_Buf_Len' => 'n/a',
+                                    'RX_Jumbo' => 'n/a',
+                                    'RX_Mini' => 'n/a',
+                                    'RX_Push' => 'n/a',
+                                    'TCP_data_split' => 'n/a',
                                     'TX' => '256',
-                                    'TX Push' => 'off',
-                                    'TX push buff len' => 'n/a'
+                                    'TX_Push' => 'off',
+                                    'TX_push_buff_len' => 'n/a'
                                   },
-                                  'Pre-set maximums' => {
+                                  'Pre-set_maximums' => {
                                     'RX' => '4096',
-                                    'RX Jumbo' => 'n/a',
-                                    'RX Mini' => 'n/a',
+                                    'RX_Jumbo' => 'n/a',
+                                    'RX_Mini' => 'n/a',
                                     'TX' => '4096',
-                                    'TX push buff len' => 'n/a'
+                                    'TX_push_buff_len' => 'n/a'
                                   }
                                 },
                                 'channels' => {
-                                  'Current hardware settings' => {
+                                  'Current_hardware_settings' => {
                                     'Combined' => '8',
                                     'Other' => '1',
                                     'RX' => 'n/a',
                                     'TX' => 'n/a'
                                   },
-                                  'Pre-set maximums' => {
+                                  'Pre-set_maximums' => {
                                     'Combined' => '63',
                                     'Other' => '1',
                                     'RX' => 'n/a',


### PR DESCRIPTION
Previously whitespaces in fact keys killed displaying this fact in Foreman. The easiest way to fix that is to replace all whitespace with underscores.