### PR TITLE
Remove EOL OS entries from metadata and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ You need to ensure that the binary is present on you system.
 
 ### Beginning with ethtool_facts
 
-The very basic steps needed for a user to get the module up and running. This
-can include setup steps, if necessary, or it can be an example of the most basic
-use of the module.
+Install the module and it will automatically make ethtool facts available via Facter. No additional setup is needed.
 
 ## Usage
 

--- a/metadata.json
+++ b/metadata.json
@@ -12,48 +12,17 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "8"
       ]
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "10"
-      ]
-    },
-    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04",
         "24.04"
-      ]
-    },
-    {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "29"
       ]
     },
     {


### PR DESCRIPTION
Removes end-of-life operating systems from `operatingsystem_support` in metadata.json:
- CentOS 7 (EOL June 2024)
- Debian 10 (EOL June 2024)
- Fedora 29 (EOL November 2019)
- Scientific Linux 7 (EOL June 2024)
- OracleLinux 7 (EOL December 2024)
- Ubuntu 18.04 (EOL April 2023)

Also replaces the PDK scaffold placeholder text in the "Beginning with ethtool_facts" README section with a brief description.