### PR TITLE
Allow rubocop upgrades without CI breakage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@
 require:
 - rubocop-performance
 - rubocop-rspec
+plugins:
+- rubocop-capybara
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.6'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.6'
+  NewCops: disable
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development do
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.5',             require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
+  gem "rubocop", '>= 1.48.1',                     require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "puppet-strings", '~> 4.0',                require: false

--- a/lib/facter/ethtool.rb
+++ b/lib/facter/ethtool.rb
@@ -60,7 +60,7 @@ Facter.add(:ethtool) do
     interfaces = physical_only ? interfaces.select { |_, attrs| attrs['physical'] == true } : interfaces
 
     result = {}
-    interfaces.each do |interface, _|
+    interfaces.each_key do |interface|
       result[interface] = {}
 
       driver_results = ethtool("-i #{interface}")


### PR DESCRIPTION
The rubocop version was pinned to exactly 1.48.1, causing Dependabot PRs that bump rubocop to fail because newer versions introduce new cops that flag existing code.

This adds `NewCops: disable` to `.rubocop.yml` so that new cops are not enforced until explicitly enabled, and relaxes the Gemfile constraint from `= 1.48.1` to `>= 1.48.1` to allow Dependabot bumps.